### PR TITLE
Limit campfire fuel input per action

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A versatile camping and campfire cooking script for FiveM that allows players to
 - **Tent and Campfire Placement:**  
   Players can place tents (which double as storage) and campfires in the game world.
   
-- **Fuel Management System:**  
-  The campfire fuel system uses various fuel types (e.g., garbage, firewood, coal) with dynamic fuel consumption affected by weather conditions.
+- **Fuel Management System:**
+  The campfire fuel system uses various fuel types (e.g., garbage, firewood, coal) with dynamic fuel consumption affected by weather conditions. Each fuel type has configurable minimum and maximum amounts that can be added per action to keep gameplay balanced.
   
 - **Cooking Mini-Game:**  
   Engage in cooking using a UI that shows recipes, progress bars, and ingredient validations. Cooking skill progression can lead to benefits like faster cook times and ingredient reductions.

--- a/client/client.lua
+++ b/client/client.lua
@@ -197,7 +197,19 @@ function FuelSystem:addFuel(itemtype, inputAmount, duration)
         return false
     end
     if not inputAmount or tonumber(inputAmount) < range.min then
-        lib.notify({ title = 'Fuel', description = 'Invalid amount provided for ' .. range.label .. '.', type = 'error' })
+        lib.notify({
+            title = 'Fuel',
+            description = 'Invalid amount provided for ' .. range.label .. '.',
+            type = 'error'
+        })
+        return false
+    end
+    if inputAmount > range.max then
+        lib.notify({
+            title = 'Fuel',
+            description = 'Cannot add more than ' .. range.max .. ' ' .. range.label .. '.',
+            type = 'error'
+        })
         return false
     end
     local totalDuration = duration * inputAmount


### PR DESCRIPTION
## Summary
- prevent adding more fuel than each type allows and notify players accordingly
- document per-action fuel limits in README

## Testing
- `luac -p client/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_689b12c920388332883c94b95d5eaf5c